### PR TITLE
Correct TensorFlow version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-tensorflow==0.12
+tensorflow==0.12.1
 numpy
 pandas
 nltk


### PR DESCRIPTION
just using 0.12 causes error:

```
 Could not find a version that satisfies the requirement tensorflow==0.12 (from -r requirements.txt (line 1)) (from versions: 0.12.1, 1.0.0, 1.1.0rc0, 1.1.0rc1, 1.1.0rc2, 1.1.0, 1.2.0rc0, 1.2.0rc1, 1.2.0rc2, 1.2.0, 1.2.1, 1.3.0rc0, 1.3.0rc1, 1.3.0rc2, 1.3.0, 1.4.0rc0, 1.4.0rc1, 1.4.0, 1.4.1, 1.5.0rc0, 1.5.0rc1, 1.5.0, 1.5.1, 1.6.0rc0, 1.6.0rc1, 1.6.0, 1.7.0rc0, 1.7.0rc1)
No matching distribution found for tensorflow==0.12 (from -r requirements.txt (line 1))
```